### PR TITLE
fix: correct CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Asimeow
 
-[![CI/CD](https://github.com/mdnmdn/asimeow/actions/workflows/pipeline.yml/badge.svg)](https://github.com/mdnmdn/asimeow/actions/workflows/rust.yml)
+[![CI/CD](https://github.com/mdnmdn/asimeow/actions/workflows/pipeline.yml/badge.svg)](https://github.com/mdnmdn/asimeow/actions/workflows/pipeline.yml)
 [![Crates.io](https://img.shields.io/crates/v/asimeow.svg)](https://crates.io/crates/asimeow)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary
- fix CI/CD badge link in README

## Testing
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_688fb0c7fd50832090d616736b8f4286